### PR TITLE
Add GetStreamURL method to encode the stream URL without executing request

### DIFF
--- a/client.go
+++ b/client.go
@@ -83,6 +83,28 @@ func (s *Client) Authenticate(password string) error {
 
 // Request performs a HTTP request against the Subsonic server as the current user.
 func (s *Client) Request(method string, endpoint string, params url.Values) (*http.Response, error) {
+	req, err := s.setupRequest(method, endpoint, params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Get is a convenience interface to issue a GET request and parse the response body (99% of Subsonic API calls)
+func (s *Client) Get(endpoint string, params map[string]string) (*Response, error) {
+	parameters := url.Values{}
+	for k, v := range params {
+		parameters.Add(k, v)
+	}
+	return s.getValues(endpoint, parameters)
+}
+
+func (s *Client) setupRequest(method string, endpoint string, params url.Values) (*http.Request, error) {
 	baseUrl, err := url.Parse(s.BaseUrl)
 	if err != nil {
 		return nil, err
@@ -112,21 +134,7 @@ func (s *Client) Request(method string, endpoint string, params url.Values) (*ht
 	}
 	req.URL.RawQuery = q.Encode()
 	//log.Printf("%s %s", method, req.URL.String())
-
-	resp, err := s.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// Get is a convenience interface to issue a GET request and parse the response body (99% of Subsonic API calls)
-func (s *Client) Get(endpoint string, params map[string]string) (*Response, error) {
-	parameters := url.Values{}
-	for k, v := range params {
-		parameters.Add(k, v)
-	}
-	return s.getValues(endpoint, parameters)
+	return req, nil
 }
 
 // getValues is a convenience interface to issue a GET request and parse the response body. It supports multiple values by way of the url.Values argument.

--- a/retrieval.go
+++ b/retrieval.go
@@ -55,6 +55,30 @@ func (s *Client) Stream(id string, parameters map[string]string) (io.Reader, err
 	return response.Body, nil
 }
 
+// GetStreamURL returns the URL for streaming the specified media. Similar to Stream,
+// except it does not actually perform the HTTP request. Useful when the streaming
+// will be handled by an outside program, e.g. mpv.
+//
+// Optional Parameters:
+//   maxBitRate:             (Since 1.2.0) If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If set to zero, no limit is imposed.
+//   format:                 (Since 1.6.0) Specifies the preferred target format (e.g., "mp3" or "flv") in case there are multiple applicable transcodings.  Starting with 1.9.0 you can use the special value "raw" to disable transcoding.
+//   timeOffset:             Only applicable to video streaming. If specified, start streaming at the given offset (in seconds) into the video. Typically used to implement video skipping.
+//   size:                   (Since 1.6.0) Only applicable to video streaming. Requested video size specified as WxH, for instance "640x480".
+//   estimateContentLength:  (Since 1.8.0). If set to "true", the Content-Length HTTP header will be set to an estimated value for transcoded or downsampled media.
+//   converted:              (Since 1.14.0) Only applicable to video streaming. Subsonic can optimize videos for streaming by converting them to MP4. If a conversion exists for the video in question, then setting this parameter to "true" will cause the converted video to be returned instead of the original.
+func (s *Client) GetStreamURL(id string, parameters map[string]string) (*url.URL, error) {
+	params := url.Values{}
+	params.Add("id", id)
+	for k, v := range parameters {
+		params.Add(k, v)
+	}
+	req, err := s.setupRequest("GET", "stream", params)
+	if err != nil {
+		return nil, err
+	}
+	return req.URL, nil
+}
+
 // Download returns a given media file. Similar to stream, but this method returns the original media data without transcoding or downsampling.
 func (s *Client) Download(id string) (io.Reader, error) {
 	params := url.Values{}


### PR DESCRIPTION
This is useful for cases when a 3rd party application will handle the actual streaming/playback, e.g. mpv.