### PR TITLE
Add .view support for API endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -153,12 +153,12 @@ func (s *Client) getValues(endpoint string, params url.Values) (*Response, error
 
 // Ping is used to test connectivity with the server. It returns true if the server is up.
 func (s *Client) Ping() bool {
-	_, err := s.Request("GET", "ping", nil)
+	resp, err := s.Request("GET", "ping", nil)
 	if err != nil {
 		log.Println(err)
 		return false
 	}
-	return true
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
 // GetLicense retrieves details about the software license. Subsonic requires a license after a 30-day trial, compatible applications have a perpetually valid license.

--- a/client.go
+++ b/client.go
@@ -33,9 +33,13 @@ type Client struct {
 	User         string
 	ClientName   string
 	PasswordAuth bool
-	password     string
-	salt         string
-	token        string
+
+	// RequireDotView will use the "(action).view" variant of the API.
+	RequireDotView bool
+
+	password string
+	salt     string
+	token    string
 }
 
 func generateSalt() string {
@@ -87,6 +91,10 @@ func (s *Client) Request(method string, endpoint string, params url.Values) (*ht
 	if err != nil {
 		return nil, err
 	}
+
+	if s.RequireDotView {
+		endpoint = endpoint + ".view"
+	}
 	baseUrl.Path = path.Join(baseUrl.Path, "/rest/", endpoint)
 	req, err := http.NewRequest(method, baseUrl.String(), nil)
 	if err != nil {
@@ -131,6 +139,7 @@ func (s *Client) Get(endpoint string, params map[string]string) (*Response, erro
 
 // getValues is a convenience interface to issue a GET request and parse the response body. It supports multiple values by way of the url.Values argument.
 func (s *Client) getValues(endpoint string, params url.Values) (*Response, error) {
+
 	response, err := s.Request("GET", endpoint, params)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,13 @@
 package subsonic
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func runClientTests(client Client, t *testing.T) {
 	t.Run("Ping", func(t *testing.T) {
@@ -17,4 +24,83 @@ func runClientTests(client Client, t *testing.T) {
 			t.Errorf("Invalid license returned- %#v\n", license)
 		}
 	})
+}
+
+func validateBaseParams(s *Client, r *http.Request) error {
+	wantU := s.User
+	gotU := r.URL.Query().Get("u")
+	if gotU != wantU {
+		return fmt.Errorf("Missing expected parameter 'u'. got='%s' want='%s'", gotU, wantU)
+	}
+
+	gotV := r.URL.Query().Get("v")
+	if !strings.HasPrefix(gotV, "1.") {
+		return fmt.Errorf("Missing expected parameter 'v'. got='%s' want='1.*'", gotV)
+	}
+
+	wantC := s.ClientName
+	gotC := r.URL.Query().Get("c")
+	if gotC != wantC {
+		return fmt.Errorf("Missing expected parameter 'c'. got='%s' want='%s'", gotC, wantC)
+	}
+
+	return nil
+}
+
+func TestPing(t *testing.T) {
+	s := &Client{
+		Client:     &http.Client{},
+		User:       "testUser",
+		ClientName: "testClient",
+	}
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := validateBaseParams(s, r); err != nil {
+			t.Errorf("validateBaseParams failed: %s", err)
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/rest/ping"):
+			io.WriteString(w, `<subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.1.1"> </subsonic-response>`)
+		default:
+			t.Errorf("Unexpected request: %s", r.URL)
+		}
+	}))
+	defer svr.Close()
+	s.BaseUrl = svr.URL
+
+	if s.Ping() != true {
+		t.Errorf("Incorrect Ping response.")
+	}
+}
+
+func TestPingDotView(t *testing.T) {
+	s := &Client{
+		Client:     &http.Client{},
+		User:       "testUser",
+		ClientName: "testClient",
+	}
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := validateBaseParams(s, r); err != nil {
+			t.Errorf("validateBaseParams failed: %s", err)
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/rest/ping"):
+			w.WriteHeader(404)
+		case strings.HasSuffix(r.URL.Path, "/rest/ping.view"):
+			io.WriteString(w, `<subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.1.1"> </subsonic-response>`)
+		default:
+			t.Errorf("Unexpected request: %s", r.URL)
+		}
+	}))
+	defer svr.Close()
+	s.BaseUrl = svr.URL
+
+	if s.Ping() != false {
+		t.Errorf("Expected Ping false for invalid endpoint.")
+	}
+
+	s.RequireDotView = true
+	if s.Ping() != true {
+		t.Errorf("Incorrect Ping response.")
+	}
+
 }


### PR DESCRIPTION
Some clients, like Ampache, only support this variant.